### PR TITLE
Add comprehensive unit tests

### DIFF
--- a/src/test/java/com/wordpress/faeldi/olx_monitor_backend/entity/EntitiesTest.java
+++ b/src/test/java/com/wordpress/faeldi/olx_monitor_backend/entity/EntitiesTest.java
@@ -1,0 +1,109 @@
+package com.wordpress.faeldi.olx_monitor_backend.entity;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EntitiesTest {
+
+    @Test
+    void userGettersAndSetters() {
+        User u = new User();
+        UUID id = UUID.randomUUID();
+        u.setId(id);
+        u.setEmail("e");
+        u.setPassword("p");
+        u.setTelegramChatId(1L);
+        u.setPlanType(PlanType.MONTHLY);
+        u.setCredits(5);
+        LocalDateTime exp = LocalDateTime.now();
+        u.setSubscriptionExpiresAt(exp);
+
+        assertEquals(id, u.getId());
+        assertEquals("e", u.getEmail());
+        assertEquals("p", u.getPassword());
+        assertEquals(1L, u.getTelegramChatId());
+        assertEquals(PlanType.MONTHLY, u.getPlanType());
+        assertEquals(5, u.getCredits());
+        assertEquals(exp, u.getSubscriptionExpiresAt());
+    }
+
+    @Test
+    void productSearchGetters() {
+        ProductSearch ps = new ProductSearch();
+        UUID id = UUID.randomUUID();
+        User u = new User();
+        ps.setId(id);
+        ps.setUser(u);
+        ps.setQuery("q");
+        ps.setActive(false);
+        ps.setFrequencyMinutes(10);
+        assertEquals(id, ps.getId());
+        assertEquals(u, ps.getUser());
+        assertEquals("q", ps.getQuery());
+        assertFalse(ps.isActive());
+        assertEquals(10, ps.getFrequencyMinutes());
+    }
+
+    @Test
+    void foundProductGetters() {
+        FoundProduct fp = new FoundProduct();
+        UUID id = UUID.randomUUID();
+        ProductSearch ps = new ProductSearch();
+        LocalDateTime time = LocalDateTime.now();
+        fp.setId(id);
+        fp.setSearch(ps);
+        fp.setTitle("t");
+        fp.setLink("l");
+        fp.setPrice(1.0);
+        fp.setPostedAt(time);
+        fp.setSentToUser(true);
+        assertEquals(id, fp.getId());
+        assertEquals(ps, fp.getSearch());
+        assertEquals("t", fp.getTitle());
+        assertEquals("l", fp.getLink());
+        assertEquals(1.0, fp.getPrice());
+        assertEquals(time, fp.getPostedAt());
+        assertTrue(fp.isSentToUser());
+    }
+
+    @Test
+    void paymentGetters() {
+        Payment p = new Payment();
+        UUID id = UUID.randomUUID();
+        User u = new User();
+        LocalDateTime time = LocalDateTime.now();
+        p.setId(id);
+        p.setUser(u);
+        p.setAmount(1.0);
+        p.setCreditsPurchased(2);
+        p.setSubscriptionUntil(time);
+        p.setPaymentMethod("m");
+        assertEquals(id, p.getId());
+        assertEquals(u, p.getUser());
+        assertEquals(1.0, p.getAmount());
+        assertEquals(2, p.getCreditsPurchased());
+        assertEquals(time, p.getSubscriptionUntil());
+        assertEquals("m", p.getPaymentMethod());
+    }
+
+    @Test
+    void notificationGetters() {
+        Notification n = new Notification();
+        UUID id = UUID.randomUUID();
+        User u = new User();
+        FoundProduct p = new FoundProduct();
+        LocalDateTime time = LocalDateTime.now();
+        n.setId(id);
+        n.setUser(u);
+        n.setProduct(p);
+        n.setSentAt(time);
+        assertEquals(id, n.getId());
+        assertEquals(u, n.getUser());
+        assertEquals(p, n.getProduct());
+        assertEquals(time, n.getSentAt());
+    }
+}

--- a/src/test/java/com/wordpress/faeldi/olx_monitor_backend/security/CustomUserDetailsServiceTest.java
+++ b/src/test/java/com/wordpress/faeldi/olx_monitor_backend/security/CustomUserDetailsServiceTest.java
@@ -1,0 +1,50 @@
+package com.wordpress.faeldi.olx_monitor_backend.security;
+
+import com.wordpress.faeldi.olx_monitor_backend.entity.PlanType;
+import com.wordpress.faeldi.olx_monitor_backend.entity.User;
+import com.wordpress.faeldi.olx_monitor_backend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class CustomUserDetailsServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    private CustomUserDetailsService service;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+        service = new CustomUserDetailsService(userRepository);
+    }
+
+    @Test
+    void userFoundReturnsDetails() {
+        User user = new User();
+        user.setEmail("a");
+        user.setPassword("p");
+        user.setPlanType(PlanType.MONTHLY);
+        when(userRepository.findByEmail("a")).thenReturn(Optional.of(user));
+        UserDetails details = service.loadUserByUsername("a");
+        assertEquals("a", details.getUsername());
+        assertEquals("p", details.getPassword());
+        assertTrue(details.getAuthorities().stream().anyMatch(a -> a.getAuthority().equals("MONTHLY")));
+    }
+
+    @Test
+    void userNotFoundThrows() {
+        when(userRepository.findByEmail(anyString())).thenReturn(Optional.empty());
+        assertThrows(UsernameNotFoundException.class, () -> service.loadUserByUsername("x"));
+    }
+}

--- a/src/test/java/com/wordpress/faeldi/olx_monitor_backend/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/wordpress/faeldi/olx_monitor_backend/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,58 @@
+package com.wordpress.faeldi.olx_monitor_backend.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class JwtAuthenticationFilterTest {
+
+    @Mock
+    private JwtService jwtService;
+    @Mock
+    private UserDetailsService userDetailsService;
+    @Mock
+    private HttpServletRequest request;
+    @Mock
+    private HttpServletResponse response;
+    @Mock
+    private FilterChain chain;
+
+    private JwtAuthenticationFilter filter;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+        filter = new JwtAuthenticationFilter(jwtService, userDetailsService);
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void noHeaderJustContinues() throws Exception {
+        when(request.getHeader("Authorization")).thenReturn(null);
+        filter.doFilterInternal(request, response, chain);
+        verify(chain).doFilter(request, response);
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    void validTokenAuthenticates() throws Exception {
+        when(request.getHeader("Authorization")).thenReturn("Bearer tok");
+        when(jwtService.extractUsername("tok")).thenReturn("user");
+        UserDetails ud = User.withUsername("user").password("p").authorities("ROLE").build();
+        when(userDetailsService.loadUserByUsername("user")).thenReturn(ud);
+        filter.doFilterInternal(request, response, chain);
+        assertNotNull(SecurityContextHolder.getContext().getAuthentication());
+        verify(chain).doFilter(request, response);
+    }
+}

--- a/src/test/java/com/wordpress/faeldi/olx_monitor_backend/security/JwtServiceTest.java
+++ b/src/test/java/com/wordpress/faeldi/olx_monitor_backend/security/JwtServiceTest.java
@@ -1,0 +1,37 @@
+package com.wordpress.faeldi.olx_monitor_backend.security;
+
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JwtServiceTest {
+
+    private JwtService jwtService;
+
+    @BeforeEach
+    void setup() throws Exception {
+        jwtService = new JwtService();
+        Field f = JwtService.class.getDeclaredField("secret");
+        f.setAccessible(true);
+        // secret must be base64 encoded, here 32 bytes key -> 256 bits
+        f.set(jwtService, java.util.Base64.getEncoder().encodeToString("12345678901234567890123456789012".getBytes()));
+    }
+
+    @Test
+    void generateAndExtract() {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("k", "v");
+        String token = jwtService.generateToken(claims, "subj");
+        assertNotNull(token);
+        Claims extracted = jwtService.extractAllClaims(token);
+        assertEquals("subj", extracted.getSubject());
+        assertEquals("v", extracted.get("k", String.class));
+        assertEquals("subj", jwtService.extractUsername(token));
+    }
+}

--- a/src/test/java/com/wordpress/faeldi/olx_monitor_backend/service/AuthServiceTest.java
+++ b/src/test/java/com/wordpress/faeldi/olx_monitor_backend/service/AuthServiceTest.java
@@ -1,0 +1,84 @@
+package com.wordpress.faeldi.olx_monitor_backend.service;
+
+import com.wordpress.faeldi.olx_monitor_backend.dto.LoginRequest;
+import com.wordpress.faeldi.olx_monitor_backend.dto.RegisterRequest;
+import com.wordpress.faeldi.olx_monitor_backend.entity.User;
+import com.wordpress.faeldi.olx_monitor_backend.repository.UserRepository;
+import com.wordpress.faeldi.olx_monitor_backend.security.JwtService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class AuthServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private AuthenticationManager authenticationManager;
+    @Mock
+    private JwtService jwtService;
+
+    private AuthService service;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+        service = new AuthService(userRepository, passwordEncoder, authenticationManager, jwtService);
+    }
+
+    @Test
+    void registerSuccess() {
+        RegisterRequest req = new RegisterRequest();
+        req.setEmail("a@a.com");
+        req.setPassword("pw");
+
+        when(userRepository.existsByEmail("a@a.com")).thenReturn(false);
+        when(passwordEncoder.encode("pw")).thenReturn("enc");
+
+        service.register(req);
+
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        User saved = captor.getValue();
+        assertEquals("a@a.com", saved.getEmail());
+        assertEquals("enc", saved.getPassword());
+    }
+
+    @Test
+    void registerDuplicate() {
+        RegisterRequest req = new RegisterRequest();
+        req.setEmail("a@a.com");
+        when(userRepository.existsByEmail("a@a.com")).thenReturn(true);
+        assertThrows(IllegalArgumentException.class, () -> service.register(req));
+    }
+
+    @Test
+    void authenticateSuccess() {
+        LoginRequest req = new LoginRequest();
+        req.setEmail("a@a.com");
+        req.setPassword("pw");
+        User u = new User();
+        u.setEmail("a@a.com");
+        when(userRepository.findByEmail("a@a.com")).thenReturn(Optional.of(u));
+        Authentication auth = mock(Authentication.class);
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class))).thenReturn(auth);
+        when(jwtService.generateToken(anyMap(), eq("a@a.com"))).thenReturn("tok");
+
+        String tok = service.authenticate(req);
+        assertEquals("tok", tok);
+    }
+}

--- a/src/test/java/com/wordpress/faeldi/olx_monitor_backend/service/FoundProductServiceTest.java
+++ b/src/test/java/com/wordpress/faeldi/olx_monitor_backend/service/FoundProductServiceTest.java
@@ -1,0 +1,103 @@
+package com.wordpress.faeldi.olx_monitor_backend.service;
+
+import com.wordpress.faeldi.olx_monitor_backend.dto.FoundProductRequest;
+import com.wordpress.faeldi.olx_monitor_backend.entity.*;
+import com.wordpress.faeldi.olx_monitor_backend.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class FoundProductServiceTest {
+
+    @Mock
+    private FoundProductRepository foundRepo;
+    @Mock
+    private ProductSearchRepository searchRepo;
+    @Mock
+    private NotificationRepository notificationRepo;
+    @Mock
+    private TelegramService telegramService;
+
+    private FoundProductService service;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+        service = new FoundProductService(foundRepo, searchRepo, notificationRepo, telegramService);
+    }
+
+    private FoundProductRequest createRequest(UUID searchId) {
+        FoundProductRequest req = new FoundProductRequest();
+        req.setSearchId(searchId);
+        req.setTitle("title");
+        req.setLink("link");
+        req.setPrice(5.0);
+        req.setPostedAt(LocalDateTime.now());
+        return req;
+    }
+
+    @Test
+    void doNothingWhenAlreadyExists() {
+        FoundProductRequest req = createRequest(UUID.randomUUID());
+        when(foundRepo.findByLink("link")).thenReturn(Optional.of(new FoundProduct()));
+        service.registerFoundProduct(req);
+        verify(searchRepo, never()).findById(any());
+    }
+
+    @Test
+    void creditPlanWithoutCreditsSkipsNotification() {
+        UUID searchId = UUID.randomUUID();
+        FoundProductRequest req = createRequest(searchId);
+        when(foundRepo.findByLink("link")).thenReturn(Optional.empty());
+        ProductSearch search = new ProductSearch();
+        search.setId(searchId);
+        User user = new User();
+        user.setPlanType(PlanType.CREDITS);
+        user.setCredits(0);
+        search.setUser(user);
+        when(searchRepo.findById(searchId)).thenReturn(Optional.of(search));
+
+        service.registerFoundProduct(req);
+
+        verify(foundRepo).save(any(FoundProduct.class));
+        verify(telegramService, never()).sendMessage(any(), any());
+        verify(notificationRepo, never()).save(any());
+    }
+
+    @Test
+    void registerAndNotify() {
+        UUID searchId = UUID.randomUUID();
+        FoundProductRequest req = createRequest(searchId);
+        when(foundRepo.findByLink("link")).thenReturn(Optional.empty());
+        ProductSearch search = new ProductSearch();
+        search.setId(searchId);
+        User user = new User();
+        user.setPlanType(PlanType.CREDITS);
+        user.setCredits(2);
+        user.setTelegramChatId(1L);
+        search.setUser(user);
+        when(searchRepo.findById(searchId)).thenReturn(Optional.of(search));
+        FoundProduct savedProduct = new FoundProduct();
+        when(foundRepo.save(any(FoundProduct.class))).thenReturn(savedProduct);
+        Notification savedNotif = new Notification();
+        when(notificationRepo.save(any(Notification.class))).thenReturn(savedNotif);
+
+        service.registerFoundProduct(req);
+
+        verify(foundRepo).save(any(FoundProduct.class));
+        verify(telegramService).sendMessage(eq(1L), contains("link"));
+        verify(notificationRepo).save(any(Notification.class));
+        assertEquals(1, user.getCredits());
+        assertTrue(savedProduct.isSentToUser());
+    }
+}

--- a/src/test/java/com/wordpress/faeldi/olx_monitor_backend/service/PaymentServiceTest.java
+++ b/src/test/java/com/wordpress/faeldi/olx_monitor_backend/service/PaymentServiceTest.java
@@ -1,0 +1,57 @@
+package com.wordpress.faeldi.olx_monitor_backend.service;
+
+import com.wordpress.faeldi.olx_monitor_backend.dto.PaymentRequest;
+import com.wordpress.faeldi.olx_monitor_backend.entity.Payment;
+import com.wordpress.faeldi.olx_monitor_backend.entity.User;
+import com.wordpress.faeldi.olx_monitor_backend.repository.PaymentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class PaymentServiceTest {
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    private PaymentService service;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+        service = new PaymentService(paymentRepository);
+    }
+
+    @Test
+    void simulatePaymentCreatesAndSaves() {
+        User user = new User();
+        user.setCredits(1);
+        PaymentRequest request = new PaymentRequest();
+        request.setAmount(10.0);
+        request.setCredits(5);
+        request.setSubscriptionUntil(LocalDateTime.now().plusDays(1));
+        request.setPaymentMethod("card");
+
+        Payment saved = new Payment();
+        when(paymentRepository.save(any(Payment.class))).thenReturn(saved);
+
+        Payment result = service.simulatePayment(user, request);
+        assertSame(saved, result);
+        ArgumentCaptor<Payment> captor = ArgumentCaptor.forClass(Payment.class);
+        verify(paymentRepository).save(captor.capture());
+        Payment p = captor.getValue();
+        assertEquals(user, p.getUser());
+        assertEquals(10.0, p.getAmount());
+        assertEquals(5, p.getCreditsPurchased());
+        assertEquals("card", p.getPaymentMethod());
+        assertEquals(request.getSubscriptionUntil(), p.getSubscriptionUntil());
+        assertEquals(6, user.getCredits());
+        assertEquals(request.getSubscriptionUntil(), user.getSubscriptionExpiresAt());
+    }
+}

--- a/src/test/java/com/wordpress/faeldi/olx_monitor_backend/service/ProductSearchServiceTest.java
+++ b/src/test/java/com/wordpress/faeldi/olx_monitor_backend/service/ProductSearchServiceTest.java
@@ -1,0 +1,85 @@
+package com.wordpress.faeldi.olx_monitor_backend.service;
+
+import com.wordpress.faeldi.olx_monitor_backend.dto.ProductSearchRequest;
+import com.wordpress.faeldi.olx_monitor_backend.entity.ProductSearch;
+import com.wordpress.faeldi.olx_monitor_backend.entity.User;
+import com.wordpress.faeldi.olx_monitor_backend.repository.ProductSearchRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ProductSearchServiceTest {
+
+    @Mock
+    private ProductSearchRepository repository;
+    private ProductSearchService service;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+        service = new ProductSearchService(repository);
+    }
+
+    @Test
+    void createSavesSearch() {
+        User user = new User();
+        ProductSearchRequest request = new ProductSearchRequest();
+        request.setQuery("test");
+        request.setFrequencyMinutes(10);
+        ProductSearch saved = new ProductSearch();
+        when(repository.save(any(ProductSearch.class))).thenReturn(saved);
+
+        ProductSearch result = service.create(user, request);
+        assertSame(saved, result);
+        ArgumentCaptor<ProductSearch> captor = ArgumentCaptor.forClass(ProductSearch.class);
+        verify(repository).save(captor.capture());
+        ProductSearch ps = captor.getValue();
+        assertEquals(user, ps.getUser());
+        assertEquals("test", ps.getQuery());
+        assertEquals(10, ps.getFrequencyMinutes());
+    }
+
+    @Test
+    void listDelegatesToRepo() {
+        User u = new User();
+        u.setId(UUID.randomUUID());
+        List<ProductSearch> list = List.of(new ProductSearch());
+        when(repository.findByUserId(u.getId())).thenReturn(list);
+        assertSame(list, service.list(u));
+    }
+
+    @Test
+    void deleteOnlyIfOwner() {
+        UUID id = UUID.randomUUID();
+        User owner = new User();
+        owner.setId(id);
+        ProductSearch ps = new ProductSearch();
+        ps.setUser(owner);
+        when(repository.findById(id)).thenReturn(Optional.of(ps));
+        service.delete(id, owner);
+        verify(repository).delete(ps);
+    }
+
+    @Test
+    void deleteWhenNotOwnerDoesNothing() {
+        UUID id = UUID.randomUUID();
+        User owner = new User();
+        owner.setId(UUID.randomUUID());
+        User other = new User();
+        other.setId(UUID.randomUUID());
+        ProductSearch ps = new ProductSearch();
+        ps.setUser(owner);
+        when(repository.findById(id)).thenReturn(Optional.of(ps));
+        service.delete(id, other);
+        verify(repository, never()).delete(any());
+    }
+}

--- a/src/test/java/com/wordpress/faeldi/olx_monitor_backend/service/TelegramServiceTest.java
+++ b/src/test/java/com/wordpress/faeldi/olx_monitor_backend/service/TelegramServiceTest.java
@@ -1,0 +1,11 @@
+package com.wordpress.faeldi.olx_monitor_backend.service;
+
+import org.junit.jupiter.api.Test;
+
+class TelegramServiceTest {
+
+    @Test
+    void sendMessageDoesNotThrow() {
+        new TelegramService().sendMessage(1L, "msg");
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for service classes and security utilities
- cover entity getters and setters

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68772aad2b10832c89665012d6a9a3bf